### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,13 +31,14 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource stopped resolving Alpine package pins across the org: every `alpine_X_YY/*` lookup returns `no-result`, so our pins are no longer updated at all and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard.

This applies the same fix that landed on app-ssh in [hassio-addons/app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119): a custom `html` datasource pointed at the Alpine CDN directory listing, which turns each `.apk` href into a version candidate.

- Added the `custom.alpine` datasource, pointed at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` (v3.24 is what this repo's `depNameTemplate` targets).
- Switched the Alpine custom manager from `repology` to `custom.alpine` and added `extractVersionTemplate` to pull the version out of the `.apk` filename. The leading `\d` in the regex is what keeps `python3` from also matching `python3-dev-...`.
- Switched the one `matchDatasources: ["repology"]` package rule to `["custom.alpine"]`. This repo only had that single rule, it has no Docker/OpenSSL/Python group rules like app-ssh does.

No community repository rule was needed here. All three pins in `sqlite-web/Dockerfile` (`nginx`, `py3-pip`, `python3`) live in Alpine `main`, checked mechanically against the v3.24 `main` and `community` APKINDEX files. If a `community` package is ever pinned in this repo, such a rule has to be added, because custom datasources use `registryStrategy: "first"` and will not fall through to a second registry URL.

### Verification

`renovate-config-validator` passes. A local dry run against this working tree (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup`, debug logging) gives:

- **3 Alpine deps extracted**, matching the 3 pins in `sqlite-web/Dockerfile` exactly: `alpine_3_24/nginx`, `alpine_3_24/py3-pip`, `alpine_3_24/python3`.
- **Zero lookup failures**: `grep -c "Found no results"` is 0, and every one of the three resolves with an empty `warnings` array and a populated `currentVersion`/`fixedVersion`.
- **Zero updates found**, which cross-checks correctly against the v3.24 `main` APKINDEX: it has `nginx=1.30.4-r1`, `py3-pip=26.1.2-r0` and `python3=3.14.7-r1`, which is precisely what the Dockerfile pins today. So no pin in this repo went stale while Repology was down, and nothing here is blocking another PR.

Worth noting that a green CI run on this PR proves nothing about the lookup: the config change does not touch the Dockerfile, so the `apk` layer comes straight from the build cache. The dry run above is the actual evidence.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the fix from https://github.com/hassio-addons/app-ssh/pull/1119 to this repository.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
